### PR TITLE
Add support for Oculus Quest

### DIFF
--- a/AvatarFavMod.cs
+++ b/AvatarFavMod.cs
@@ -76,7 +76,7 @@ namespace AvatarFav
         void OnLevelWasLoaded(int level)
         {
             VRCModLogger.Log("[AvatarFav] OnLevelWasLoaded (" + level + ")");
-            if (level == 1 && !alreadyLoaded)
+            if (level == (Application.platform == RuntimePlatform.WindowsPlayer ? 1 : 2) && !alreadyLoaded)
             {
                 alreadyLoaded = true;
 


### PR DESCRIPTION
This doesn't do a whole lot, just ensures that AvatarFav's OnLevelWasLoaded is compatible with Quest's wierd scene layout. Everything else should remain the same, and was tested on both PC and Quest.

Special thanks goes to @HerpDerpinstine for helping me with this!